### PR TITLE
[maven-python-mojos]: Change build directory from "py" to "python"

### DIFF
--- a/maven-python-plugin/README.md
+++ b/maven-python-plugin/README.md
@@ -85,7 +85,7 @@ If a version number is specified in the setup.py it will override both options a
 * Python interpreter (to build the dist): `<pythonExecutable>"python"</pythonExecutable>`
 * Python source directory: `<sourceDirectory>"${project.basedir}/src/main/python"</sourceDirectory>`
 * Python package version: `<packageVersion>"${project.version}"</packageVersion>`
-* Python package build: `<pythonBuild>sdist</pythonBuild>`
+* Python package build (possible values: `sdist`, `bdist_egg`, `bdist_wheel`): `<pythonBuild>sdist</pythonBuild>`
 
 `install` phase:
 

--- a/maven-python-plugin/pom.xml
+++ b/maven-python-plugin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.sqooba</groupId>
 		<artifactId>maven-python-mojos</artifactId>
-		<version>1.1.1-SNAPSHOT</version>
+		<version>1.1.2-SNAPSHOT</version>
 	</parent>
 
 	<groupId>io.sqooba</groupId>

--- a/maven-python-plugin/src/main/java/io/sqooba/maven/python/PackageEnum.java
+++ b/maven-python-plugin/src/main/java/io/sqooba/maven/python/PackageEnum.java
@@ -6,7 +6,7 @@ package io.sqooba.maven.python;
 public enum PackageEnum {
         sdist("sdist"),
         bdist_egg("bdist_egg"),
-        bdist_wheels("bdist_wheel");
+        bdist_wheel("bdist_wheel");
 
         private final String text;
 

--- a/maven-python-plugin/src/main/java/io/sqooba/maven/python/Utils.java
+++ b/maven-python-plugin/src/main/java/io/sqooba/maven/python/Utils.java
@@ -13,7 +13,7 @@ public class Utils {
 
   private static final String PYTHON_NAME = "python";
   private static final String PIP_NAME = "pip";
-  private static final String PYTHON_DIST_DIRECTORY = "py";
+  private static final String PYTHON_DIST_DIRECTORY = "python";
   public static final String SEPARATOR = ";";
 
   public static Boolean verifyContains(String command, String expectedExecName) {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.sqooba</groupId>
 	<artifactId>maven-python-mojos</artifactId>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>1.1.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
1) Fixed typo in `PackageEnum`: `bdist_wheels` --> `bdist_wheel`
2) Change build directory: `target/py/` --> `target/python/`. This is to accommodate changes in the jenkins library to be able to automatically deploy python artifacts to our repo